### PR TITLE
Logging level fixes

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -89,7 +89,7 @@ func Middleware(config Config) echo.MiddlewareFunc {
 			if err != nil {
 				evt = logger.log.Err(err)
 			} else {
-				evt = logger.log.Info()
+				evt = logger.log.WithLevel(logger.log.GetLevel())
 			}
 			evt.Str("remote_ip", c.RealIP())
 			evt.Str("host", req.Host)

--- a/middleware.go
+++ b/middleware.go
@@ -2,6 +2,7 @@ package lecho
 
 import (
 	"context"
+	"github.com/rs/zerolog"
 	"os"
 	"strconv"
 	"time"
@@ -84,7 +85,12 @@ func Middleware(config Config) echo.MiddlewareFunc {
 
 			stop := time.Now()
 
-			evt := logger.log.Info()
+			var evt *zerolog.Event
+			if err != nil {
+				evt = logger.log.Err(err)
+			} else {
+				evt = logger.log.Info()
+			}
 			evt.Str("remote_ip", c.RealIP())
 			evt.Str("host", req.Host)
 			evt.Str("method", req.Method)
@@ -92,11 +98,6 @@ func Middleware(config Config) echo.MiddlewareFunc {
 			evt.Str("user_agent", req.UserAgent())
 			evt.Int("status", res.Status)
 			evt.Str("referer", req.Referer())
-
-			if err != nil {
-				evt.Err(err)
-			}
-
 			evt.Dur("latency", stop.Sub(start))
 			evt.Str("latency_human", stop.Sub(start).String())
 


### PR DESCRIPTION
All logs, including errors, are currently logged as INFO. This PR makes error log as level ERROR. Additionally, there is currently no way to change the logging level from INFO to something else. Even passing a custom level logger does not have any effect. This PR uses the logger's minimum level instead of hardcoded INFO.