### PR TITLE
Support nesting request metrics under a sub dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ func main() {
 }
 ```
 
+### Nesting under a sub dictionary
+
+```go
+e.Use(lecho.Middleware(lecho.Config{
+        Logger: logger,
+        NestKey: "request"
+    }))
+    // Output: {"level":"info","request":{"remote_ip":"5.6.7.8","method":"GET", ...}, ...}
+```
+
 ## Helpers
 
 ### Level converters


### PR DESCRIPTION
In some cases you don't want the fields of the request metrics directly
in the root of the dictionary.

For example, when sending general application logs *and* request metric
logs to the same ES index it's good to be able to to nest the request
metrics as a separate object.

This commit adds 1 extra config option `NestKey` holding the name of
a key, that when set will nest the request metric fields in a sub
dictionary under the key name.